### PR TITLE
Add basic Node.js task list app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# mistareas
+# Mis Tareas
+
+Aplicación sencilla de lista de tareas con Node.js y HTML.
+
+## Uso
+
+1. Ejecuta el servidor:
+   ```
+   npm start
+   ```
+2. Abre `http://localhost:3000` en tu navegador para administrar la lista de tareas.
+
+## Pruebas
+
+No existen pruebas automatizadas, pero se puede ejecutar:
+```
+npm test
+```
+para verificar que el entorno funciona.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "mistareas",
+  "version": "1.0.0",
+  "description": "Aplicación simple de tareas",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "node -e \"console.log('No tests');\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,45 @@
+async function loadTasks() {
+  const res = await fetch('/api/tasks');
+  const tasks = await res.json();
+  const list = document.getElementById('tasks');
+  list.innerHTML = '';
+  tasks.forEach(t => {
+    const li = document.createElement('li');
+    li.textContent = `${t.titulo} - ${t.descripcion} `;
+    const select = document.createElement('select');
+    const estados = ['pendiente', 'en_ejecucion', 'finalizado'];
+    estados.forEach(e => {
+      const option = document.createElement('option');
+      option.value = e;
+      option.textContent = e.replace('_', ' ');
+      select.appendChild(option);
+    });
+    select.value = t.estado;
+    select.onchange = async () => {
+      await fetch(`/api/tasks/${t.id}`, {
+        method: 'PUT',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({estado: select.value})
+      });
+      loadTasks();
+    };
+    li.appendChild(select);
+    list.appendChild(li);
+  });
+}
+
+document.getElementById('taskForm').addEventListener('submit', async e => {
+  e.preventDefault();
+  const titulo = document.getElementById('titulo').value;
+  const descripcion = document.getElementById('descripcion').value;
+  const estado = document.getElementById('estado').value;
+  await fetch('/api/tasks', {
+    method: 'POST',
+    headers: {'Content-Type': 'application/json'},
+    body: JSON.stringify({titulo, descripcion, estado})
+  });
+  e.target.reset();
+  loadTasks();
+});
+
+window.onload = loadTasks;

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <title>Mis Tareas</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <h1>Mis Tareas</h1>
+  <form id="taskForm">
+    <input type="text" id="titulo" placeholder="Título" required>
+    <input type="text" id="descripcion" placeholder="Descripción">
+    <select id="estado">
+      <option value="pendiente">Pendiente</option>
+      <option value="en_ejecucion">En ejecución</option>
+      <option value="finalizado">Finalizado</option>
+    </select>
+    <button type="submit">Agregar</button>
+  </form>
+  <ul id="tasks"></ul>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,8 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 20px;
+}
+
+#tasks li {
+  margin: 5px 0;
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,82 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+let tasks = [];
+let nextId = 1;
+const allowedStatuses = ['pendiente', 'en_ejecucion', 'finalizado'];
+
+function sendJSON(res, statusCode, data) {
+  res.writeHead(statusCode, {'Content-Type': 'application/json'});
+  res.end(JSON.stringify(data));
+}
+
+function serveStatic(req, res) {
+  const filePath = path.join(__dirname, 'public', req.url === '/' ? 'index.html' : req.url);
+  fs.readFile(filePath, (err, content) => {
+    if (err) {
+      res.writeHead(404);
+      res.end('Not Found');
+    } else {
+      const ext = path.extname(filePath).toLowerCase();
+      const typeMap = {
+        '.html': 'text/html',
+        '.js': 'text/javascript',
+        '.css': 'text/css'
+      };
+      res.writeHead(200, {'Content-Type': typeMap[ext] || 'text/plain'});
+      res.end(content);
+    }
+  });
+}
+
+const server = http.createServer((req, res) => {
+  if (req.url.startsWith('/api/tasks')) {
+    if (req.method === 'GET' && req.url === '/api/tasks') {
+      sendJSON(res, 200, tasks);
+    } else if (req.method === 'POST' && req.url === '/api/tasks') {
+      let body = '';
+      req.on('data', chunk => body += chunk);
+      req.on('end', () => {
+        const data = JSON.parse(body || '{}');
+        const status = allowedStatuses.includes(data.estado) ? data.estado : 'pendiente';
+        const task = {
+          id: nextId++,
+          titulo: data.titulo || '',
+          descripcion: data.descripcion || '',
+          estado: status
+        };
+        tasks.push(task);
+        sendJSON(res, 201, task);
+      });
+    } else if (req.method === 'PUT') {
+      const id = parseInt(req.url.split('/')[3], 10);
+      const task = tasks.find(t => t.id === id);
+      if (!task) {
+        res.writeHead(404);
+        return res.end();
+      }
+      let body = '';
+      req.on('data', chunk => body += chunk);
+      req.on('end', () => {
+        const data = JSON.parse(body || '{}');
+        if (data.titulo !== undefined) task.titulo = data.titulo;
+        if (data.descripcion !== undefined) task.descripcion = data.descripcion;
+        if (data.estado && allowedStatuses.includes(data.estado)) {
+          task.estado = data.estado;
+        }
+        sendJSON(res, 200, task);
+      });
+    } else {
+      res.writeHead(405);
+      res.end();
+    }
+  } else {
+    serveStatic(req, res);
+  }
+});
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Servidor escuchando en http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- create minimal Node.js server with in-memory tasks and REST endpoints
- add HTML/JS front-end to list, create, and update tasks with status
- document usage in README

## Testing
- `npm test`
- `node server.js` & `curl -s http://localhost:3000/api/tasks`
- `curl -s -X POST -H "Content-Type: application/json" -d '{"titulo":"Demo","descripcion":"Probar","estado":"en_ejecucion"}' http://localhost:3000/api/tasks`
- `curl -s http://localhost:3000/api/tasks`


------
https://chatgpt.com/codex/tasks/task_e_689373e47d94832d83d5a64ff3569ba8