### PR TITLE
Integrar Bootstrap y campo de creación de tareas

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -5,8 +5,15 @@ async function loadTasks() {
   list.innerHTML = '';
   tasks.forEach(t => {
     const li = document.createElement('li');
-    li.textContent = `${t.titulo} - ${t.descripcion} `;
+    li.className = 'list-group-item d-flex align-items-center';
+
+    const text = document.createElement('span');
+    text.className = 'flex-grow-1';
+    text.textContent = `${t.titulo} - ${t.descripcion}`;
+    li.appendChild(text);
+
     const select = document.createElement('select');
+    select.className = 'form-select w-auto ms-2';
     const estados = ['pendiente', 'en_ejecucion', 'finalizado'];
     estados.forEach(e => {
       const option = document.createElement('option');
@@ -24,6 +31,30 @@ async function loadTasks() {
       loadTasks();
     };
     li.appendChild(select);
+
+    const createdDiv = document.createElement('div');
+    createdDiv.className = 'form-check form-switch ms-3';
+    const createdCheck = document.createElement('input');
+    createdCheck.className = 'form-check-input';
+    createdCheck.type = 'checkbox';
+    createdCheck.id = `creada-${t.id}`;
+    createdCheck.checked = t.creada;
+    createdCheck.onchange = async () => {
+      await fetch(`/api/tasks/${t.id}`, {
+        method: 'PUT',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({creada: createdCheck.checked})
+      });
+      loadTasks();
+    };
+    const createdLabel = document.createElement('label');
+    createdLabel.className = 'form-check-label';
+    createdLabel.htmlFor = createdCheck.id;
+    createdLabel.textContent = 'Creada';
+    createdDiv.appendChild(createdCheck);
+    createdDiv.appendChild(createdLabel);
+    li.appendChild(createdDiv);
+
     list.appendChild(li);
   });
 }
@@ -33,10 +64,11 @@ document.getElementById('taskForm').addEventListener('submit', async e => {
   const titulo = document.getElementById('titulo').value;
   const descripcion = document.getElementById('descripcion').value;
   const estado = document.getElementById('estado').value;
+  const creada = document.getElementById('creada').checked;
   await fetch('/api/tasks', {
     method: 'POST',
     headers: {'Content-Type': 'application/json'},
-    body: JSON.stringify({titulo, descripcion, estado})
+    body: JSON.stringify({titulo, descripcion, estado, creada})
   });
   e.target.reset();
   loadTasks();

--- a/public/index.html
+++ b/public/index.html
@@ -3,21 +3,39 @@
 <head>
   <meta charset="UTF-8">
   <title>Mis Tareas</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="styles.css">
 </head>
-<body>
-  <h1>Mis Tareas</h1>
-  <form id="taskForm">
-    <input type="text" id="titulo" placeholder="Título" required>
-    <input type="text" id="descripcion" placeholder="Descripción">
-    <select id="estado">
-      <option value="pendiente">Pendiente</option>
-      <option value="en_ejecucion">En ejecución</option>
-      <option value="finalizado">Finalizado</option>
-    </select>
-    <button type="submit">Agregar</button>
-  </form>
-  <ul id="tasks"></ul>
+<body class="bg-light">
+  <div class="container py-5">
+    <h1 class="mb-4 text-center">Mis Tareas</h1>
+    <form id="taskForm" class="row g-3 mb-4">
+      <div class="col-md-4">
+        <input type="text" id="titulo" placeholder="Título" class="form-control" required>
+      </div>
+      <div class="col-md-4">
+        <input type="text" id="descripcion" placeholder="Descripción" class="form-control">
+      </div>
+      <div class="col-md-2">
+        <select id="estado" class="form-select">
+          <option value="pendiente">Pendiente</option>
+          <option value="en_ejecucion">En ejecución</option>
+          <option value="finalizado">Finalizado</option>
+        </select>
+      </div>
+      <div class="col-md-1 d-flex align-items-center">
+        <div class="form-check">
+          <input class="form-check-input" type="checkbox" id="creada">
+          <label class="form-check-label" for="creada">Creada</label>
+        </div>
+      </div>
+      <div class="col-md-1 d-grid">
+        <button type="submit" class="btn btn-primary">Agregar</button>
+      </div>
+    </form>
+    <ul id="tasks" class="list-group"></ul>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
   <script src="app.js"></script>
 </body>
 </html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,8 +1,7 @@
 body {
   font-family: Arial, sans-serif;
-  margin: 20px;
 }
 
 #tasks li {
-  margin: 5px 0;
+  margin-bottom: 5px;
 }

--- a/server.js
+++ b/server.js
@@ -44,7 +44,8 @@ const server = http.createServer((req, res) => {
           id: nextId++,
           titulo: data.titulo || '',
           descripcion: data.descripcion || '',
-          estado: status
+          estado: status,
+          creada: data.creada === true
         };
         tasks.push(task);
         sendJSON(res, 201, task);
@@ -65,6 +66,7 @@ const server = http.createServer((req, res) => {
         if (data.estado && allowedStatuses.includes(data.estado)) {
           task.estado = data.estado;
         }
+        if (data.creada !== undefined) task.creada = data.creada === true;
         sendJSON(res, 200, task);
       });
     } else {


### PR DESCRIPTION
## Summary
- Añadido Bootstrap al frontend y reorganizado el formulario y listado con clases modernas.
- Incorporado campo **Creada** para cada tarea, con soporte para envío y edición.
- Servidor actualizado para almacenar y actualizar el estado de creación.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893794e3d2c832d9a183c15d0ce9e30